### PR TITLE
Mvp api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # ShareLockers
 
 ##MVP API:
-Verb |	URL	| Action
------|------|-------
-GET	| /locker/{id} |	Lists details on locker (hub, row, column, owner)
-POST|	/locker/{id} |	Opens locker, sets owner to current user
-GET|	/profile/{id} |	Show user details
-GET	| /hub/{id} |	Show a list of lockers at this hub and their owners and available actions (Open)
+Verb |	URL	        | Action
+-----|--------------|-------
+GET	| /lockers/{id}  |	Lists details on locker (hub, row, column, owner)
+POST| /lockers/{id}  |	Opens locker, sets owner to current user
+GET|  /profiles/{id} |	Show user details
+GET	| /hubs/{id}     |	Show a list of lockers at this hub and their owners and available actions (Open)
+
+##Other endpoints:
+Verb |	URL	        | Action
+-----|--------------|-------
+GET	| /lockers/     | Lists my lockers (for current user)
+GET | /profiles/    | List registered profiles
+POST| /lockers/     | Create a new locker
+
+

--- a/sharelockers/sharelockers/api/serializers.py
+++ b/sharelockers/sharelockers/api/serializers.py
@@ -1,13 +1,19 @@
 from lockers.models import Locker
 from profiles.models import Profile
+from hubs.models import Hub
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
 
 class LockerSerializer(serializers.ModelSerializer): #FIXME: add Hyperlinked
+    can_open = serializers.SerializerMethodField()
+
     class Meta:
         model = Locker
-        fields = ('hub', 'row', 'column', 'owner',)
+        fields = ('hub', 'row', 'column', 'owner', 'can_open')
+
+    def get_can_open(self, obj):
+        return True  # FIXME: Add validation that I am the owner
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
@@ -18,3 +24,10 @@ class ProfileSerializer(serializers.ModelSerializer): #FIXME: add Hyperlinked
     class Meta:
         model = Profile
         fields = ('user', 'rating', 'description', 'alias')
+
+class HubSerializer(serializers.ModelSerializer):
+    locker_set = LockerSerializer(many=True, read_only=True)  # A nested list of 'locker' items.
+
+    class Meta:
+        model = Hub
+        fields = ('name','location', 'ip', 'locker_set')

--- a/sharelockers/sharelockers/api/serializers.py
+++ b/sharelockers/sharelockers/api/serializers.py
@@ -1,9 +1,10 @@
 from lockers.models import Locker
+from profiles.models import Profile
 from django.contrib.auth.models import User
 from rest_framework import serializers
 
 
-class LockerSerializer(serializers.HyperlinkedModelSerializer):
+class LockerSerializer(serializers.ModelSerializer): #FIXME: add Hyperlinked
     class Meta:
         model = Locker
         fields = ('hub', 'row', 'column', 'owner',)
@@ -12,3 +13,8 @@ class LockerSerializer(serializers.HyperlinkedModelSerializer):
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
+
+class ProfileSerializer(serializers.ModelSerializer): #FIXME: add Hyperlinked
+    class Meta:
+        model = Profile
+        fields = ('user', 'rating', 'description', 'alias')

--- a/sharelockers/sharelockers/api/urls.py
+++ b/sharelockers/sharelockers/api/urls.py
@@ -5,7 +5,7 @@ from api import views
 
 router = routers.DefaultRouter()
 router.register(r'lockers', views.LockerViewSet, base_name="lockers")
-router.register(r'users', views.ProfileViewSet, base_name="profiles")
+router.register(r'profiles', views.ProfileViewSet, base_name="profiles")
 
 urlpatterns = [
     url(r'^api/', include(router.urls)),

--- a/sharelockers/sharelockers/api/urls.py
+++ b/sharelockers/sharelockers/api/urls.py
@@ -1,10 +1,11 @@
 from django.conf.urls import include, url
 from rest_framework import routers
 from api import views
+import profiles.views
 
 router = routers.DefaultRouter()
 router.register(r'lockers', views.LockerViewSet, base_name="lockers")
-router.register(r'users', views.UserViewSet, base_name="users")
+router.register(r'users', profiles.views.ProfileViewSet, base_name="profiles")
 
 urlpatterns = [
     url(r'^api/', include(router.urls)),

--- a/sharelockers/sharelockers/api/urls.py
+++ b/sharelockers/sharelockers/api/urls.py
@@ -1,11 +1,11 @@
 from django.conf.urls import include, url
 from rest_framework import routers
 from api import views
-import profiles.views
+# import profiles.views
 
 router = routers.DefaultRouter()
 router.register(r'lockers', views.LockerViewSet, base_name="lockers")
-router.register(r'users', profiles.views.ProfileViewSet, base_name="profiles")
+router.register(r'users', views.ProfileViewSet, base_name="profiles")
 
 urlpatterns = [
     url(r'^api/', include(router.urls)),

--- a/sharelockers/sharelockers/api/urls.py
+++ b/sharelockers/sharelockers/api/urls.py
@@ -6,6 +6,7 @@ from api import views
 router = routers.DefaultRouter()
 router.register(r'lockers', views.LockerViewSet, base_name="lockers")
 router.register(r'profiles', views.ProfileViewSet, base_name="profiles")
+router.register(r'hubs', views.HubViewSet, base_name="hubs")
 
 urlpatterns = [
     url(r'^api/', include(router.urls)),

--- a/sharelockers/sharelockers/api/views.py
+++ b/sharelockers/sharelockers/api/views.py
@@ -2,7 +2,8 @@ from django.shortcuts import render
 from rest_framework import viewsets, generics, permissions
 from lockers.models import Locker
 from profiles.models import Profile
-from .serializers import LockerSerializer, UserSerializer, ProfileSerializer
+from hubs.models import Hub, Location
+from .serializers import LockerSerializer, UserSerializer, ProfileSerializer, HubSerializer
 from django.contrib.auth.models import User
 
 
@@ -26,3 +27,10 @@ class ProfileViewSet(viewsets.ModelViewSet):
     """
     queryset = Profile.objects.all()
     serializer_class = ProfileSerializer
+
+class HubViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows hubs to be viewed or edited.
+    """
+    queryset = Hub.objects.all()
+    serializer_class = HubSerializer

--- a/sharelockers/sharelockers/api/views.py
+++ b/sharelockers/sharelockers/api/views.py
@@ -1,14 +1,16 @@
 from django.shortcuts import render
 from rest_framework import viewsets, generics, permissions
 from lockers.models import Locker
-from .serializers import LockerSerializer, UserSerializer
+from profiles.models import Profile
+from .serializers import LockerSerializer, UserSerializer, ProfileSerializer
 from django.contrib.auth.models import User
+
 
 class LockerViewSet(viewsets.ModelViewSet):
     serializer_class = LockerSerializer
 
     def get_queryset(self):
-        return Locker.objects.filter(owner = self.request.user)
+        return Locker.objects.filter(owner = self.request.user.profile)
 
     def perform_create(self, serializer):
         serializer.save(owner = self.request.user)
@@ -17,3 +19,10 @@ class LockerViewSet(viewsets.ModelViewSet):
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+
+class ProfileViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows user profiles to be viewed or edited.
+    """
+    queryset = Profile.objects.all()
+    serializer_class = ProfileSerializer

--- a/sharelockers/sharelockers/api/views.py
+++ b/sharelockers/sharelockers/api/views.py
@@ -13,7 +13,7 @@ class LockerViewSet(viewsets.ModelViewSet):
         return Locker.objects.filter(owner = self.request.user.profile)
 
     def perform_create(self, serializer):
-        serializer.save(owner = self.request.user)
+        serializer.save(owner = self.request.user.profile)
 
 
 class UserViewSet(viewsets.ModelViewSet):

--- a/sharelockers/sharelockers/hubs/models.py
+++ b/sharelockers/sharelockers/hubs/models.py
@@ -9,6 +9,8 @@ class Location(models.Model):
     host = models.ForeignKey(Profile, null=True, related_name="managed_location")
     residents = models.ManyToManyField(Profile, related_name="nearby_location", related_query_name="nearby_locations")
 
+    def __str__(self):
+        return self.description
 
 class Hub(models.Model):
     name = models.CharField(max_length=255)
@@ -16,3 +18,6 @@ class Hub(models.Model):
     secret_key = models.CharField(max_length=255, db_index=True)
     occupied = models.BooleanField(default=False)
     ip = models.CharField(null=True, max_length=255, db_index=True)
+
+    def __str__(self):
+        return self.name

--- a/sharelockers/sharelockers/lockers/models.py
+++ b/sharelockers/sharelockers/lockers/models.py
@@ -5,7 +5,6 @@ from profiles.models import Profile
 
 class Locker(models.Model):
     hub = models.ForeignKey(Hub)
-    row = models.IntegerField()
     column_options = (
         (1, 'A'),
         (2, 'B'),
@@ -17,7 +16,11 @@ class Locker(models.Model):
         (8, 'H')
     )
     column = models.IntegerField(choices=column_options)
+    row = models.IntegerField()
     owner = models.ForeignKey(Profile, null=True) # FIXME remove after MVP
 
     class Meta:
         unique_together = ('hub', 'row', 'column',)
+
+    def __str__(self):
+        return 'h:{}-c:{}-r:{}'.format(self.hub, self.column, self.row)

--- a/sharelockers/sharelockers/profiles/admin.py
+++ b/sharelockers/sharelockers/profiles/admin.py
@@ -3,7 +3,5 @@ from .models import Profile
 from profiles.forms import UserForm
 
 
-class UserAdmin(admin.ModelAdmin):
-    form = UserForm
 
-admin.site.register(Profile, UserAdmin)
+admin.site.register(Profile)

--- a/sharelockers/sharelockers/profiles/forms.py
+++ b/sharelockers/sharelockers/profiles/forms.py
@@ -16,3 +16,9 @@ class UserForm(forms.ModelForm):
         if commit:
             user.save()
         return user
+
+
+class ProfileForm(forms.ModelForm):
+    class Meta:
+        model = Profile
+        fields = ('description', 'alias')

--- a/sharelockers/sharelockers/profiles/models.py
+++ b/sharelockers/sharelockers/profiles/models.py
@@ -8,5 +8,6 @@ class Profile(models.Model):
     description = models.TextField(max_length=255, null=True)
     alias = models.CharField(max_length=255)
 
-    d
+    def __str__(self):
+        return self.alias
 

--- a/sharelockers/sharelockers/profiles/models.py
+++ b/sharelockers/sharelockers/profiles/models.py
@@ -1,6 +1,5 @@
 from django.db import models
 from django.contrib.auth.models import User
-from rest_framework import serializers
 
 
 class Profile(models.Model):
@@ -9,8 +8,5 @@ class Profile(models.Model):
     description = models.TextField(max_length=255, null=True)
     alias = models.CharField(max_length=255)
 
+    d
 
-class ProfileSerializer(serializers.ModelSerializer): #FIXME: add Hyperlinked
-    class Meta:
-        model = Profile
-        fields = ('user', 'rating', 'description', 'alias')

--- a/sharelockers/sharelockers/profiles/models.py
+++ b/sharelockers/sharelockers/profiles/models.py
@@ -1,9 +1,16 @@
 from django.db import models
 from django.contrib.auth.models import User
+from rest_framework import serializers
 
 
 class Profile(models.Model):
     user = models.OneToOneField(User)
-    rating = models.IntegerField()
-    description = models.TextField(max_length=255)
+    rating = models.IntegerField(null=True, default=0)
+    description = models.TextField(max_length=255, null=True)
     alias = models.CharField(max_length=255)
+
+
+class ProfileSerializer(serializers.ModelSerializer): #FIXME: add Hyperlinked
+    class Meta:
+        model = Profile
+        fields = ('user', 'rating', 'description', 'alias')

--- a/sharelockers/sharelockers/profiles/templates/profiles/register.html
+++ b/sharelockers/sharelockers/profiles/templates/profiles/register.html
@@ -6,6 +6,7 @@
     <form method="POST" action="{% url 'user_register' %}">
         {% csrf_token %}
         {{ user_form.as_p }}
+        {{ profile_form.as_p }}
 
         <!-- Provide a button to click to submit the form. -->
         <input type="submit" name="submit" value="Register"/>

--- a/sharelockers/sharelockers/profiles/views.py
+++ b/sharelockers/sharelockers/profiles/views.py
@@ -3,15 +3,23 @@ from django.contrib.auth import authenticate, login
 from django.shortcuts import redirect
 from django.contrib import messages
 from profiles.models import Profile
-from profiles.forms import UserForm
+from profiles.models import ProfileSerializer
+from profiles.forms import UserForm, ProfileForm
+from rest_framework import viewsets
+
 
 def user_register(request):
     if request.method == "GET":
         user_form = UserForm()
+        profile_form = ProfileForm()
     elif request.method == "POST":
         user_form = UserForm(request.POST)
-        if user_form.is_valid():
+        profile_form = ProfileForm(request.POST)
+        if user_form.is_valid() and profile_form.is_valid():
             user = user_form.save()
+            profile = profile_form.save(commit=False)
+            profile.user = user
+            profile.save()
             password = user.password
             user.set_password(password)
             user.save()
@@ -23,4 +31,12 @@ def user_register(request):
                 "Congratulations, {}, on creating your new account! You are now logged in.".format(
                     user.username))
             return redirect('view_index')
-    return render(request, "profiles/register.html", {'user_form': user_form})
+    return render(request, "profiles/register.html", {'user_form': user_form,
+                                                      'profile_form': profile_form,
+                                                      })
+class ProfileViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows user profiles to be viewed or edited.
+    """
+    queryset = Profile.objects.all()
+    serializer_class = ProfileSerializer

--- a/sharelockers/sharelockers/profiles/views.py
+++ b/sharelockers/sharelockers/profiles/views.py
@@ -3,9 +3,7 @@ from django.contrib.auth import authenticate, login
 from django.shortcuts import redirect
 from django.contrib import messages
 from profiles.models import Profile
-from profiles.models import ProfileSerializer
 from profiles.forms import UserForm, ProfileForm
-from rest_framework import viewsets
 
 
 def user_register(request):
@@ -34,9 +32,4 @@ def user_register(request):
     return render(request, "profiles/register.html", {'user_form': user_form,
                                                       'profile_form': profile_form,
                                                       })
-class ProfileViewSet(viewsets.ModelViewSet):
-    """
-    API endpoint that allows user profiles to be viewed or edited.
-    """
-    queryset = Profile.objects.all()
-    serializer_class = ProfileSerializer
+


### PR DESCRIPTION
Covers basic functionality of API endpoints listed in (updated) README
NOTE: Endpoints have changed slightly from yesterday (they've been pluralized)

Other notes:
Hubs and lockers can be created and viewed through the API
PUTting to an existing locker lets you change the owner (if you currently own it)
Users/profiles must be created through normal django registration, but are viewable from API
Locations must be made through the django-admin interface currently (no endpoint yet), but there is only 1 location for MVP

Issues:
  I can create a normal account successfully, but only log in as a superuser once I log out
  No hyperlinks in the API browser
  Currently, "can_open" is set to True at all times for all lockers, but will need to have user authentication incorporated
  Not present: whatever magic is required to actually physically open the locker
  